### PR TITLE
edit usu.config remove sysnum_separator

### DIFF
--- a/usu.config
+++ b/usu.config
@@ -14,4 +14,3 @@ usu.oclc_field = 035a
 usu.oclc_function = get_oclc_num
 usu.source = USU
 usu.sysnum_function = sdr_id_from_001
-usu.sysnum_separator = .


### PR DESCRIPTION
Hi @jsjiang - Can you please review at your convenience? The only change I made was to remove the sysnum_separator setting. Test results after doing this look good. Thanks!